### PR TITLE
Update UnixBench for machines with more than 128 processors

### DIFF
--- a/lib/UnixBenchTest.php
+++ b/lib/UnixBenchTest.php
@@ -244,8 +244,8 @@ class UnixBenchTest {
       // create runs cript
       fwrite($fp, "#!/bin/bash\n");
       fwrite($fp, sprintf("cd %s\n", $this->options['unixbench_dir']));
-      // increase copy limit from 16 to 128 (if not already changed)
-      fwrite($fp, "sed -i 's/=> 16/=> 128/g' Run\n");
+      // increase copy limit from 16 to 640 (if not already changed, systems are getting much bigger...)
+      fwrite($fp, "sed -i 's/=> 16/=> 640/g' Run\n");
       fwrite($fp, sprintf("./Run%s%s %s >%s 2>>%s\n", isset($this->options['nosinglethread']) ? '' : ' -c 1', isset($this->options['nomultithread']) && $this->options['multicore_copies'] > 1 ? '' : ' -c ' . $this->options['multicore_copies'], implode(' ', $this->options['test']), $ofile, $efile));
       fwrite($fp, sprintf("echo \$? >%s\n", $xfile));
       fclose($fp);
@@ -317,7 +317,7 @@ class UnixBenchTest {
   public function validateRunOptions() {
     $this->getRunOptions();
     $validate = array(
-      'multicore_copies' => array('min' => 1, 'max' => 128),
+      'multicore_copies' => array('min' => 1, 'max' => 640),
       'output' => array('required' => TRUE, 'write' => TRUE),
       'test' => array('option' => explode(' ', self::UNIX_BENCH_TESTS), 'required' => TRUE)
     );


### PR DESCRIPTION
UnixBench is currently restricted to a maximum of 128 processors; however, some more recent computers (including VMs) have 400+, so we raised the limit to 640.  We tested this fix and it seems to work fine.